### PR TITLE
Allow loading llama2_7b model

### DIFF
--- a/src/main/scala/net/virtualvoid/llama2/Llama2.scala
+++ b/src/main/scala/net/virtualvoid/llama2/Llama2.scala
@@ -14,13 +14,14 @@ import java.nio.channels.FileChannel
  * @param seqLen max sequence length
  */
 case class Config(
-    dim:       Int,
-    hiddenDim: Int,
-    nLayers:   Int,
-    nHeads:    Int,
-    nKvHeads:  Int,
-    vocabSize: Int,
-    seqLen:    Int
+    dim:           Int,
+    hiddenDim:     Int,
+    nLayers:       Int,
+    nHeads:        Int,
+    nKvHeads:      Int,
+    vocabSize:     Int,
+    seqLen:        Int,
+    sharedWeights: Boolean
 ) {
   def headSize: Int = dim / nHeads
 }
@@ -626,15 +627,14 @@ object Llama2Main extends App {
       b1 | (b2 << 8) | (b3 << 16) | (b4 << 24)
     }
 
-    Config(
-      dim = readInt(),
-      hiddenDim = readInt(),
-      nLayers = readInt(),
-      nHeads = readInt(),
-      nKvHeads = readInt(),
-      vocabSize = readInt(),
-      seqLen = readInt()
-    )
+    val dim = readInt()
+    val hiddenDim = readInt()
+    val nLayers = readInt()
+    val nHeads = readInt()
+    val nKvHeads = readInt()
+    val vocabSize = readInt()
+    val seqLen = readInt()
+    Config(dim, hiddenDim, nLayers, nHeads, nKvHeads, vocabSize.abs, seqLen, vocabSize > 0)
   }
 
   def readVocab(config: Config, tokenizerFile: File): Vocab = {


### PR DESCRIPTION
On top of an intermediate state of introducing more lightweight abstractions.

The model needs to be generated as described in https://github.com/karpathy/llama2.c#metas-llama-2-models. It's incredibly slow (~ 15s per token) running on a single core as it currently is.