### PR TITLE
q8 quantization

### DIFF
--- a/jvm/src/main/scala/net/virtualvoid/llama2/Buffers.scala
+++ b/jvm/src/main/scala/net/virtualvoid/llama2/Buffers.scala
@@ -25,7 +25,7 @@ object Buffers {
     def d1(dim1: Int): Tensor1D = Tensor1D(next(dim1), dim1)
     def d2(dim1: Int, dim2: Int): Tensor2D = Tensor2D(next(dim1 * dim2), dim1, dim2)
     def d3(dim1: Int, dim2: Int, dim3: Int): Tensor3D = {
-      val elements = for (i <- 0 until dim1) yield d2(dim2, dim3)
+      val elements = for (i <- 0 until dim1) yield d2(dim2, dim3).quantizeQ8
 
       new Tensor3D {
         override def size0: Int = dim1

--- a/shared/src/main/scala/net/virtualvoid/llama2/Tensor.scala
+++ b/shared/src/main/scala/net/virtualvoid/llama2/Tensor.scala
@@ -178,10 +178,12 @@ trait Tensor2D {
 
   def toFloatArray: Array[Float]
   def toFloatBuffer: FloatBuffer
+
+  def quantizeQ8: Tensor2D
 }
 
 object Tensor2D {
-  def apply(fb: FloatBuffer, dim1: Int, dim2: Int): Tensor2D = new Tensor2D {
+  def apply(fb: FloatBuffer, dim1: Int, dim2: Int): Tensor2D = new Tensor2D { outer =>
     val floatBuffer = fb.duplicate()
     def size0: Int = dim1
     def size1: Int = dim2
@@ -210,6 +212,175 @@ object Tensor2D {
 
     def toFloatArray: Array[Float] = ???
     def toFloatBuffer: FloatBuffer = floatBuffer.duplicate()
+
+    def quantizeQ8: Tensor2D = {
+      val K = 32
+      require(size1 % K == 0)
+
+      val numBlocks = size0 * size1 / K
+
+      //lazy val (quantized, quantizeFactor) = {
+      val quantized = new Array[Byte](size0 * size1)
+      val quantizeFactor = new Array[Float](numBlocks)
+
+      var i = 0
+      while (i < numBlocks) {
+        //println(s"Block ${i}")
+        var j = 0
+        var max = 0f
+        while (j < K) {
+          val v = floatBuffer.get(i * K + j).abs
+          if (v > max) max = v
+          j += 1
+        }
+        //println(s"Max: ${max}")
+
+        val d = max / ((1 << 7) - 1)
+        val id = if (d != 0f) 1.0f / d else 0.0f
+        //println(f"Quantize factor: ${d}%.6f inverse: ${id}%.6f")
+
+        quantizeFactor(i) = d
+        //println(f"[$i%2d] max: $max%.6f Quantize factor: ${d}%.6f inverse: ${id}%.6f First: ${floatBuffer.get(i * K)}%.6f)}")
+
+        j = 0
+        while (j < K) {
+          val v = floatBuffer.get(i * K + j)
+          val x0 = v * id // scale
+          quantized(i * K + j) = math.round(x0).toByte
+          //println(f"At ${i * K + j} v: $v%.6f x0: ${x0} quantized: ${quantized(i * K + j)}")
+          j += 1
+        }
+
+        i += 1
+      }
+
+      //(quantized, quantizeFactor)
+      //}
+
+      new Tensor2D {
+        def size0: Int = dim1
+        def size1: Int = dim2
+
+        def apply(i: Int): Tensor1D = ???
+
+        def `@`(v: Tensor1DMut): Op1D = { dest =>
+          val arr = v.toFloatArray
+          require(arr.length % K == 0)
+          val quantizedV = new Array[Byte](arr.size)
+          val numBlocksV = arr.size / K
+          val quantizeVFactor = new Array[Float](numBlocksV)
+
+          {
+            var i = 0
+            while (i < numBlocksV) {
+              var j = 0
+              var max = 0f
+              while (j < K) {
+                val v = arr(i * K + j).abs
+                if (v > max) max = v
+                j += 1
+              }
+
+              val d = max / ((1 << 7) - 1)
+              val id = if (d != 0f) 1.0f / d else 0.0f
+
+              quantizeVFactor(i) = d
+              j = 0
+              while (j < K) {
+                val x0 = arr(i * K + j) * id // scale
+                quantizedV(i * K + j) = math.round(x0).toByte
+                j += 1
+              }
+
+              i += 1
+            }
+          }
+
+          var i = 0
+          while (i < dim1) {
+            var j = 0
+            var sum = 0.0f
+            var sum2 = 0f
+            require(numBlocksV * 32 == dim2)
+            while (j < numBlocksV) {
+              var sumq = 0
+              //var sumc = 0f
+              var k = 0
+              while (k < K) {
+                sumq += quantized(i * dim2 + j * K + k) * quantizedV(j * K + k)
+                //sumc += floatBuffer.get(i * dim2 + j * K + k) * arr(j * K + k)
+                k += 1
+              }
+              val sumq2 = sumq.toFloat * quantizeFactor(i * dim2 / K + j) * quantizeVFactor(j)
+              //println((sumq2 - sumc, sumq2, sumc))
+              //if (math.abs(sumq2 - sumc) / sumc > 0.7f) {
+              if (false) {
+                //if (i == 1) {
+                //println(s"Error at $i $j $K $dim1 $dim2 ${i * dim2 + j}: ${sumq2 - sumc} $sumq2 $sumc")
+                //println(math.abs(sumq2 - sumc))
+                var k = 0
+                while (k < K) {
+                  val d1 = quantizeFactor(i * dim2 / K + j)
+                  val qv1 = quantized(i * dim2 + j * K + k)
+                  val q1 = qv1 * d1
+                  val d2 = quantizeVFactor(j)
+                  val q2 = quantizedV(j * K + k) * d2
+                  val o1 = floatBuffer.get(i * dim2 + j * K + k)
+                  val o2 = arr(j * K + k)
+
+                  val qr = q1 * q2
+                  val or = o1 * o2
+                  println(f"$k%2d: $q1%9.6f ($qv1%4d) * $q2%9.6f = $qr%9.6f $d1%9.6f $d2%9.6f ${o1 / d1} ${math.round(o1 * 1f / d1).toByte}")
+                  println(f"$k%2d: $o1%9.6f ($qv1%4d) * $o2%9.6f = $or%8.5f")
+
+                  k += 1
+                }
+
+                {
+                  var k = 0
+                  var max = 0f
+                  while (k < K) {
+                    val v = floatBuffer.get(i * dim2 + j * K + k).abs
+                    if (v > max) max = v
+                    k += 1
+                  }
+                  println(s"Max: ${max}")
+
+                  val d = max / ((1 << 7) - 1).toFloat
+                  val id = if (d != 0f) 1.0f / d else 0.0f
+                  println(f"Quantize factor: ${d}%9.6f inverse: ${id}%9.6f")
+
+                  //quantizeFactor(i) = d
+                  k = 0
+                  while (k < K) {
+                    val v = floatBuffer.get(i * dim2 + j * K + k)
+                    val x0 = v * id // scale
+                    val q = math.round(x0).toByte
+                    println(f"At ${k}%2d / ${i * dim2 + j * K + k}%4d v: $v%9.6f x0: ${x0}%9.6f quantized: ${q}%4d")
+                    k += 1
+                  }
+                }
+
+                ???
+              }
+              sum += sumq2
+              //sum2 += sumc
+
+              j += 1
+            }
+
+            //println(sum -> sum2)
+            dest(i) = sum
+            i += 1
+          }
+        }
+
+        def toFloatArray: Array[Float] = ???
+        def toFloatBuffer: FloatBuffer = ???
+
+        def quantizeQ8: Tensor2D = this
+      }
+    }
   }
 
   implicit def autoBuffer(t2: Tensor2D): FloatBuffer = t2.toFloatBuffer
@@ -235,6 +406,7 @@ object Tensor2DMut {
 
     def toFloatArray: Array[Float] = if (offset == 0 && fs.length == dim1 * dim2) fs else ???
     def toFloatBuffer: FloatBuffer = ???
+    def quantizeQ8: Tensor2D = ???
   }
 }
 trait Tensor3D {
@@ -283,5 +455,7 @@ object Tensor3DMut {
     def apply(i: Int): Tensor2DMut = Tensor2DMut(floats, dim2, dim3, offset = i * dim2 * dim3)
     def toFloatArray: Array[Float] = floats
     def toFloatBuffer: FloatBuffer = ???
+
+    def quantize: Tensor3D = ???
   }
 }

--- a/shared/src/main/scala/net/virtualvoid/llama2/Weights.scala
+++ b/shared/src/main/scala/net/virtualvoid/llama2/Weights.scala
@@ -41,6 +41,6 @@ object Weights {
     val headSize = config.dim / config.nHeads
     val freq_cis_real = d2(config.seqLen, headSize / 2)
     val freq_cis_imag = d2(config.seqLen, headSize / 2)
-    val wcls = if (config.sharedWeights) tokenEmbeddingTable else d2(config.vocabSize, config.dim)
+    val wcls = if (config.sharedWeights) tokenEmbeddingTable.quantizeQ8 else d2(config.vocabSize, config.dim).quantizeQ8
   }
 }


### PR DESCRIPTION
This creates q8 quantized values for all weights used in matrix multiplications when loading a model.

It makes running llama2_7b more bearable at ~ 0.45 tok/s.